### PR TITLE
Print file name of failure

### DIFF
--- a/source/brstest.brs
+++ b/source/brstest.brs
@@ -132,11 +132,12 @@ End Function
 'Begin Class TestFixture
 'A single test to be executed which is utilized by the TestCase class
 'for execution and the TestResult class for reporting on the result.
-Function brstNewTestFixture(TestFunc as Object, TestName as String, TestDescription as String) as Object
+Function brstNewTestFixture(TestFunc as Object, TestName as String, TestDescription as String, TestScriptPath as String) as Object
     new_fix = CreateObject("roAssociativeArray")
     new_fix.TestFunc = TestFunc
     new_fix.FuncName = TestName
     new_fix.Descript = TestDescription
+    new_fix.TestScriptPath = TestScriptPath
     return new_fix
 End Function
 'End Class TestFixture
@@ -734,6 +735,7 @@ Sub brstTtrPrintErrorList(flavour as string, errors as object)
         test=err_item[0]
         err=err_item[1]
         m.writeline(m.separator1)
+        m.writeline(test._fixture.testScriptPath)
         m.writeline(flavour + ": " + m.getDescription(test))
         m.writeline(m.separator2)
         m.writeline(err)
@@ -916,7 +918,7 @@ Function brstTlFixturesFromScript(scriptpath as string) as Object
     'Returns an enumerable of TestFixture objects from the
     'contents of a script file designated
     code = m.readFile(scriptpath)
-    return m.fixturesFromScriptContents(code)
+    return m.fixturesFromScriptContents(code, scriptpath)
 End Function
 
 Function brstTlReadFile(fromfile as string) as string
@@ -925,7 +927,7 @@ Function brstTlReadFile(fromfile as string) as string
     return ReadAsciiFile(fromfile)
 End Function
 
-Function brstTlFixturesFromScriptContents(scriptstr as string) as Object
+Function brstTlFixturesFromScriptContents(scriptstr as string, scriptpath as string) as Object
     'Returns an enumerable of TestFixture objects from the contents
     'of a test script file
     'Assumes that the code file has already been compiled and the
@@ -945,7 +947,7 @@ Function brstTlFixturesFromScriptContents(scriptstr as string) as Object
             fname = tokens[0]
             if UCase(Left(fname, len(m.testMethodPrefix))) = UCase(m.testMethodPrefix) then 
                 eval("fobj=" + fname)
-                fixt = brstNewTestFixture(fobj, fname, "")
+                fixt = brstNewTestFixture(fobj, fname, "", scriptpath)
                 fixtures.AddTail(fixt)
             end if
         end if

--- a/source/test_testcase.brs
+++ b/source/test_testcase.brs
@@ -4,14 +4,14 @@
 Sub testTestCase_ToString_EqualToMethodName(t as object)
     'To string should return the test method name
     methodname = "testfoobar"
-    fixture = brstNewTestFixture("", methodname, "")
+    fixture = brstNewTestFixture("", methodname, "", "")
     tc = brstNewTestCase(fixture)
     t.assertEqual(methodname, tc.toString())
 End Sub
 
 Sub testTestCase_ShortDescription_EmptyIfNoDescSpecified(t as object)
     'Empty string return if no description specified
-    fixture = brstNewTestFixture("", "", "")
+    fixture = brstNewTestFixture("", "", "", "")
     tc = brstNewTestCase(fixture)
     t.assertEqual("", tc.shortDescription())
 End Sub
@@ -21,7 +21,7 @@ Sub testTestCase_ShortDescription_OnlyFirstLineReturned(t as object)
     expected_desc = "This is the first line of the test description"
     full_desc = expected_desc + chr(10) + "This is the second line"
     full_desc = full_desc     + chr(10) + "This is the third line"
-    fixture = brstNewTestFixture("", "", full_desc)
+    fixture = brstNewTestFixture("", "", full_desc, "")
     tc = brstNewTestCase(fixture)
     t.assertEqual(expected_desc, tc.shortDescription())
 End Sub
@@ -29,13 +29,13 @@ End Sub
 Sub testTestCase_ShortDescription_SingleLineDescHandled(t as object)
     'Single line description should be returned as itself
     expected_desc = "This is the first line of the test description"
-    fixture = brstNewTestFixture("", "", expected_desc)
+    fixture = brstNewTestFixture("", "", expected_desc, "")
     tc = brstNewTestCase(fixture)
     t.assertEqual(expected_desc, tc.shortDescription())
 End Sub
 
 Sub assertEqualMessageForNotEquals(t as object, val1 as object, val2 as object, ExpectedMessage as object)
-    fixture = brstNewTestFixture("", "", "")
+    fixture = brstNewTestFixture("", "", "", "")
     tc = brstNewTestCase(fixture)
     tc.ErrorMessage = ""
     tc.fail = function(msg as string) 
@@ -55,7 +55,7 @@ Sub assertEqualMessageForNotEquals(t as object, val1 as object, val2 as object, 
 End Sub
 
 Sub assertEqualMessageForEquals(t as object, val1 as object, val2 as object)
-    fixture = brstNewTestFixture("", "", "")
+    fixture = brstNewTestFixture("", "", "", "")
     tc = brstNewTestCase(fixture)
     tc.ErrorMessage = ""
     tc.fail = function(msg as string) 
@@ -68,7 +68,7 @@ Sub assertEqualMessageForEquals(t as object, val1 as object, val2 as object)
 End Sub
 
 Sub assertNotEqualMessageForEquals(t as object, val1 as object, val2 as object, ExpectedMessage as string)
-    fixture = brstNewTestFixture("", "", "")
+    fixture = brstNewTestFixture("", "", "", "")
     tc = brstNewTestCase(fixture)
     tc.ErrorMessage = ""
     tc.fail = function(msg as string) 
@@ -82,7 +82,7 @@ Sub assertNotEqualMessageForEquals(t as object, val1 as object, val2 as object, 
 End Sub
 
 Sub assertNotEqualNoMessageForNotEquals(t as object, val1 as object, val2 as object)
-    fixture = brstNewTestFixture("", "", "")
+    fixture = brstNewTestFixture("", "", "", "")
     tc = brstNewTestCase(fixture)
     tc.ErrorMessage = ""
     tc.fail = function(msg as string) 
@@ -545,7 +545,7 @@ End Sub
 sub testTestCase_EqValues_FunctionOnDifferentObject_AreNotEqual(t as object)
     'True if two function arguments are from different 'objects' but the
     'same function
-    fixture = brstNewTestFixture("", "", "")
+    fixture = brstNewTestFixture("", "", "", "")
     tc = brstNewTestCase(fixture)
     x = t.assertEqual
     y = tc.assertEqual

--- a/source/test_testloader.brs
+++ b/source/test_testloader.brs
@@ -46,7 +46,7 @@ Sub testTestLoader_fixturesFromScriptContents_FunctionWithoutPrefixNotReturned(t
     sub_code = sub_code + chr(10)
     
     tl = brstNewTestLoader("Test", "test")
-    fixtures = tl.fixturesFromScriptContents(sub_code)
+    fixtures = tl.fixturesFromScriptContents(sub_code, "")
 
     'No fixtures should be returned
     t.assertEqual(0, fixtures.Count())
@@ -63,7 +63,7 @@ sub_code = sub_code + chr(10)
 sub_code = sub_code + "'End Sub"
 sub_code = sub_code + chr(10)
     tl = brstNewTestLoader("Test", "test")
-    fixtures = tl.fixturesFromScriptContents(sub_code)
+    fixtures = tl.fixturesFromScriptContents(sub_code, "")
 
     'No fixtures should be returned
     t.assertEqual(0, fixtures.Count())
@@ -82,7 +82,7 @@ sub_code = sub_code + chr(10)
     subref = testTestLoader_fixturesFromScriptContents_TestSubFound
     sdesc = "" '<--Update once message parsing is added
     tl = brstNewTestLoader("Test", "test")
-    fixtures = tl.fixturesFromScriptContents(sub_code)
+    fixtures = tl.fixturesFromScriptContents(sub_code, "")
 
     'Only one fixture should be returned
     t.assertEqual(1, fixtures.Count())
@@ -110,7 +110,7 @@ func_code = func_code + chr(10)
     func = testTestLoader_fixturesFromScriptContents_TestFunctionFound
     fdesc = "" '<--Update once message parsing is added
     tl = brstNewTestLoader("Test", "test")
-    fixtures = tl.fixturesFromScriptContents(func_code)
+    fixtures = tl.fixturesFromScriptContents(func_code, "")
     t.assertEqual(1, fixtures.Count())
 
     fixture = fixtures[0]
@@ -126,7 +126,7 @@ End Function
 Sub testTestLoader_fixturesFromScriptContents_NoneFound(t as object)
     'Emtpy enumerable return if no tests were found
     tl = brstNewTestLoader("Test", "test")
-    fixtures = tl.fixturesFromScriptContents("")
+    fixtures = tl.fixturesFromScriptContents("", "")
     t.assertEqual(0, fixtures.Count())
 End Sub
 

--- a/source/test_testsuite.brs
+++ b/source/test_testsuite.brs
@@ -176,5 +176,11 @@ Sub testtsCountTestCasesZeroIfNoTests(t as object)
     t.assertEqual(0, actual_tests)
 End Sub
 
+Sub testttsPrintFileNameOnFailure(t as object)
+    tl = brstNewTestLoader("Test", "test")
+    fixtures = tl.fixturesFromScript("pkg:/source/test_examples.brs")
+    t.assertEqual("pkg:/source/test_examples.brs", fixtures[0].testScriptPath)
+End Sub
+
 
 


### PR DESCRIPTION
I was finding that for a larger suite of tests, it was becoming trickier to find the file that a failing test function was contained in.

The PR modifies the output to print the file name above the failing test function name.

e.g.

'''
------ Running ------
# ...........................................................................................F

pkg:/source/test_testsuite.brs
## FAIL: testttsPrintFileNameOnFailure

"pkg:/source/test_exampless.brs" != "pkg:/source/test_examples.brs"

---

'''

This can be demonstrated by making a test in test_examples.brs fail and running make install.
